### PR TITLE
Fixing "Active Buff Trigger" regex typo/old version

### DIFF
--- a/src/triggers/Auto Buffs/triggers.json
+++ b/src/triggers/Auto Buffs/triggers.json
@@ -53,7 +53,7 @@
               "highlightBG": "#ffff00",
               "patterns": [
                      {
-                            "pattern": "\\s*(?\u003caffect\u003e.+)\\s*: In affect for (?\u003ctime\u003e\\d+) mins\\.$",
+                            "pattern": "\\s*(?\u003caffect\u003e.+)\\s*: In affect for (?\u003ctime\u003e\\d+) minutes\\.$",
                             "type": "regex"
                      }
               ],


### PR DESCRIPTION
Current version rebuffs every buff upon 'status' command, this is a fix for the regex to actually match and the script to register that the buffs are active and do not need rebuffing.